### PR TITLE
Cart facelift and 'add to cart' functionality added to product card component

### DIFF
--- a/client/components/Cart.js
+++ b/client/components/Cart.js
@@ -1,5 +1,64 @@
-import React from 'react';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
 
-const Cart = () => <h1>Welcome to the non-functioning cart!</h1>;
+class Cart extends Component {
+  constructor() {
+    super();
+    this.state = {
+      // Store quantity changes here?
+    };
+  }
 
-export default Cart;
+  render() {
+    const { cart, products } = this.props;
+    return (
+      <div className="container">
+        <div className="row">
+          <div className="col-6 col-sm-8 col-lg-10">
+            <h5>Product Name</h5>
+          </div>
+          <div className="col-3 col-sm-2 col-lg-1">
+            <h5>Quantity</h5>
+          </div>
+          <div className="col-3 col-sm-2 col-lg-1">
+            <h5>Price</h5>
+          </div>
+        </div>
+        {Object.keys(cart).map(id => {
+          const quantity = cart[id];
+          return (
+            <div key={id} className="row my-1">
+              <div className="col-6 col-sm-8 col-lg-10">
+                {products[id].name}
+              </div>
+              <div className="col-3 col-sm-2 col-lg-1">
+                <input
+                  className="form-control form-control-sm"
+                  type="text"
+                  placeholder={quantity}
+                />
+              </div>
+              <div className="col-3 col-sm-2 col-lg-1">
+                {products[id].price}
+              </div>
+            </div>
+          );
+        })}
+        <div className="row">
+          <div className="col-12">
+            <button type="button" className="btn btn-secondary mt-3">
+              Update Cart
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapState = state => {
+  const { cart, products } = state;
+  return { cart, products };
+};
+
+export default connect(mapState)(Cart);

--- a/client/components/ProductCard.js
+++ b/client/components/ProductCard.js
@@ -1,8 +1,11 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { connect } from 'react-redux';
+import { changeCart } from '../store/cart';
 
 const ProductCard = props => {
-  const { product } = props;
+  const { product, cart } = props;
+
   return (
     <div className="col-12 col-md-6 col-lg-4">
       <div className="card">
@@ -17,13 +20,35 @@ const ProductCard = props => {
           <Link to={`/products/${product.id}`} className="btn btn-primary mr-3">
             Info
           </Link>
-          <Link to={`/products/`} className="btn btn-success">
-            Buy! (temp)
-          </Link>
+          <button
+            type="button"
+            className="btn btn-success"
+            onClick={() => {
+              props.changeCart({
+                ...cart,
+                [product.id]: cart[product.id] + 1 || 1
+              });
+            }}
+          >
+            Add to Cart
+          </button>
         </div>
       </div>
     </div>
   );
 };
 
-export default ProductCard;
+const mapState = state => {
+  const { cart } = state;
+  return { cart };
+};
+
+const mapDispatch = dispatch => {
+  return {
+    changeCart: cart => {
+      dispatch(changeCart(cart));
+    }
+  };
+};
+
+export default connect(mapState, mapDispatch)(ProductCard);


### PR DESCRIPTION
Implemented basic cart functionality.  Cart still needs work in order to store quantity changes on state, then dispatch a changeCart thunk with the updated data.

Changed product card to grab the cart state and dispatch changeCart when the "add to cart" button is clicked.  This currently adds one additional item for each click.